### PR TITLE
Mycdrdata updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 .vagrant
 *.log
 *.tar.gz
+drg.tar

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,12 @@
         {
             "type": "node",
             "request": "attach",
+            "name": "Attach MockRegister PM2",
+            "port": 9293
+        },
+        {
+            "type": "node",
+            "request": "attach",
             "name": "Attach to a process",
             "processId": "${command:PickProcess}"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,12 @@
         {
             "type": "node",
             "request": "attach",
+            "name": "Attach MTLS Mock DH proxy PM2",
+            "port": 9292
+        },
+        {
+            "type": "node",
+            "request": "attach",
             "name": "Attach to a process",
             "processId": "${command:PickProcess}"
         },

--- a/examples/deployment/pm2/ecosystem.config.js
+++ b/examples/deployment/pm2/ecosystem.config.js
@@ -65,6 +65,7 @@ const env = {
   // DH_OIDC_DCR_ENDPOINT: 'https://localhost:10202/idp/register',
   // DH_OIDC_JWKS_ENDPOINT: 'http://localhost:8201/jwks',
 
+  //APPINSIGHTS_INSTRUMENTATIONKEY: ""
 }
 
 const env_production = {

--- a/examples/deployment/pm2/ecosystem.config.js
+++ b/examples/deployment/pm2/ecosystem.config.js
@@ -11,7 +11,7 @@ const env = {
   // NO_PROXY: "localhost",
   
   //LOG_FILE: "debug.log.txt",
-  LOG_LEVEL: "info",
+  LOG_LEVEL: "debug",
 
   /** JWKS service (optional). Provides a single source of truth JWKS in a microservice. Any URL could be used instead */
   /** JWKS can also be supplied in the ADR_JWKS var as a JSON string or URL */

--- a/examples/deployment/pm2/ecosystem.config.js
+++ b/examples/deployment/pm2/ecosystem.config.js
@@ -149,6 +149,7 @@ module.exports = {
     watch: false,
     max_memory_restart: '1G',
     env,
-    env_production
+    env_production,
+    node_args: "--inspect --inspect-port 9292"
   }]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,6 +1045,17 @@
         "default-require-extensions": "^3.0.0"
       }
     },
+    "applicationinsights": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.8.10.tgz",
+      "integrity": "sha512-ZLDA7mShh4mP2Z/HlFolmvhBPX1LfnbIWXrselyYVA7EKjHhri1fZzpu2EiWAmfbRxNBY6fRjoPJWbx5giKy4A==",
+      "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
+        "diagnostic-channel": "0.3.1",
+        "diagnostic-channel-publishers": "0.4.4"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1185,6 +1196,14 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -1195,7 +1214,6 @@
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dev": true,
       "requires": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
@@ -1366,6 +1384,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blessed": {
       "version": "0.1.81",
@@ -1847,6 +1875,16 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1969,7 +2007,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dev": true,
       "requires": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
@@ -2318,7 +2355,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
@@ -2758,6 +2799,19 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
+    "diagnostic-channel": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
+      "integrity": "sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz",
+      "integrity": "sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -2808,7 +2862,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dev": true,
       "requires": {
         "shimmer": "^1.2.0"
       }
@@ -5179,6 +5232,13 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.10.tgz",
@@ -6807,8 +6867,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -6929,8 +6988,7 @@
     "shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "dev": true
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7210,6 +7268,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -7591,9 +7654,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
+      "integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA=="
     },
     "uglify-js": {
       "version": "3.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7328,7 +7328,8 @@
       "version": "4.34.6",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.6.tgz",
       "integrity": "sha512-JWcrnfBqkws9R12jTYF7+zl59bdhL/+sw6efHZllIdtztrRfyykL4Bbr0aTRHQqDP0tjFhZOlRHifPSSmdqmFg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tar": {
       "version": "2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adr-gateway",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "npx rimraf dist && npm run build-templates && npx tsc && npx cpx package.json dist",
     "clean": "npx rimraf dist",
     "evidence-clean": "npx rimraf .evidence",
+    "restart:pm2": "node ./node_modules/pm2/bin/pm2 restart examples/deployment/pm2/ecosystem.config.js",
     "start:pm2": "node ./node_modules/pm2/bin/pm2 delete examples/deployment/pm2/ecosystem.config.js && node ./node_modules/pm2/bin/pm2 start examples/deployment/pm2/ecosystem.config.js",
     "start": "set PM2_HOME=&& npm run build && npm run start:pm2",
     "up:docker": "docker-compose -f ./examples/deployment/docker/docker-compose.yml up --build -d",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=14"
   },
   "dependencies": {
+    "applicationinsights": "^1.8.10",
     "axios": "^0.21.1",
     "base64url": "^3.0.1",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "npx rimraf dist",
     "evidence-clean": "npx rimraf .evidence",
     "start:pm2": "node ./node_modules/pm2/bin/pm2 delete examples/deployment/pm2/ecosystem.config.js && node ./node_modules/pm2/bin/pm2 start examples/deployment/pm2/ecosystem.config.js",
-    "start": "npm run build && npm run start:pm2",
+    "start": "set PM2_HOME=&& npm run build && npm run start:pm2",
     "up:docker": "docker-compose -f ./examples/deployment/docker/docker-compose.yml up --build -d",
     "down:docker": "docker-compose -f ./examples/deployment/docker/docker-compose.yml down",
     "start:docker": "docker-compose -f ./examples/deployment/docker/docker-compose.yml start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adr-gateway",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "A gateway ready to interact with the Australian Consumer Data Right ecosystem. Allows Accredited Data Recipients to quickly deploy their software products and participate in the CDR without needing to develop the complexities of boiler-plate data recipient interactions.",
   "author": "Regional Australia Bank",
   "engines": {

--- a/src/AdrGateway/Server/Helpers/HybridAuthJWS.ts
+++ b/src/AdrGateway/Server/Helpers/HybridAuthJWS.ts
@@ -31,6 +31,9 @@ const FetchRequestUri = async (cert: ClientCertificateInjector, signed:string, $
   DataHolderOidc: Types.DataholderOidcResponse,
   CheckAndUpdateClientRegistration: Types.DataHolderRegistration,
   DataRecipientJwks: Types.JWKS.KeyStore
+}, queryParams : {
+  scope: string,
+  response_type: string
 }) => {
 
   const url = $.DataHolderOidc.pushed_authorization_request_endpoint;
@@ -41,6 +44,8 @@ const FetchRequestUri = async (cert: ClientCertificateInjector, signed:string, $
     "client_id": $.CheckAndUpdateClientRegistration.clientId,
     "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
     "client_assertion": CreateAssertion($.CheckAndUpdateClientRegistration.clientId, url, $.DataRecipientJwks),
+    scope: queryParams.scope,
+    response_type: queryParams.response_type
   }))
 
   let options: AxiosRequestConfig = {
@@ -138,7 +143,7 @@ export const getAuthPostGetRequestUrl = async (cert: ClientCertificateInjector, 
   }
 
   if (usePar) {
-    const {request_uri} = await FetchRequestUri(cert,signed,$)
+    const {request_uri} = await FetchRequestUri(cert,signed,$,payload)
     url.searchParams.append('request_uri', request_uri);
   } else {
     url.searchParams.append('request', signed);

--- a/src/AdrGateway/Server/Helpers/HybridAuthJWS.ts
+++ b/src/AdrGateway/Server/Helpers/HybridAuthJWS.ts
@@ -56,7 +56,9 @@ const FetchRequestUri = async (cert: ClientCertificateInjector, signed:string, $
   }
 
   cert.inject(options);
+
   let response = await axios.request(options);
+ 
   return {request_uri: response.data.request_uri}
 }
 

--- a/src/AdrGateway/Server/Instrumentation.ts
+++ b/src/AdrGateway/Server/Instrumentation.ts
@@ -1,0 +1,9 @@
+function loadInstrumentation() {
+//If Application Insights configured, start it
+if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+    var applicationInsights = require("applicationinsights");
+    applicationInsights.setup().start();
+}
+}
+
+export { loadInstrumentation };

--- a/src/AdrGateway/Server/Middleware/ConsentRequest.ts
+++ b/src/AdrGateway/Server/Middleware/ConsentRequest.ts
@@ -33,7 +33,7 @@ const bodySchema:Schema = {
     state: { isString: { errorMessage: "state must be a string" }, isLength: {options: {min: 5}, errorMessage: "state must be at least length 5"} },
     scopes: {isArray:true, errorMessage: "authorized scopes must be presented as an array"},
     'scopes.*': {isString: true, errorMessage: "all scopes must be strings"},
-    redirectUri: {isString: { errorMessage: "redirectUri must be a URI string"}}
+    redirectUri: {optional: true, isString: { errorMessage: "redirectUri must be a URI string"}}
 };
 
 const querySchema:Schema = {

--- a/src/AdrGateway/Server/Middleware/ConsentRequest.ts
+++ b/src/AdrGateway/Server/Middleware/ConsentRequest.ts
@@ -32,7 +32,8 @@ const bodySchema:Schema = {
     systemId: { isString: { errorMessage: "systemId must be a string" }, isLength: {options: {min: 1}, errorMessage: "systemId must be at least length 1"} },
     state: { isString: { errorMessage: "state must be a string" }, isLength: {options: {min: 5}, errorMessage: "state must be at least length 5"} },
     scopes: {isArray:true, errorMessage: "authorized scopes must be presented as an array"},
-    'scopes.*': {isString: true, errorMessage: "all scopes must be strings"}
+    'scopes.*': {isString: true, errorMessage: "all scopes must be strings"},
+    redirectUri: {isString: { errorMessage: "redirectUri must be a URI string"}}
 };
 
 const querySchema:Schema = {
@@ -59,7 +60,7 @@ class ConsentRequestMiddleware {
     
         let Responder = async (req:express.Request,res:express.Response) => {
     
-            let m:ConsentRequestParams = <any>matchedData(req);
+            let m:ConsentRequestParams = <any>matchedData(req, {includeOptionals: true});
 
             try {
                 let redirect_uri = await this.RequestConsent(m);

--- a/src/AdrGateway/Server/Middleware/ConsumerDataAccess.ts
+++ b/src/AdrGateway/Server/Middleware/ConsumerDataAccess.ts
@@ -180,7 +180,8 @@ class ConsumerDataAccessMiddleware {
 
 
         let options:AxiosRequestConfig = {
-            method: "GET",
+            method: <AxiosRequestConfig["method"]>req.method,
+            data: req.body,
             url: url.toString(),
             headers: headers,
             responseType:"json"
@@ -190,7 +191,7 @@ class ConsumerDataAccessMiddleware {
             requestStatus: "sending",
             consentId: consent.id,
             url: url.toString(),
-            method: "GET",
+            method: <AxiosRequestConfig["method"]>req.method,
             requestId,
             headers,
         })

--- a/src/AdrGateway/Server/Middleware/UserInfo.ts
+++ b/src/AdrGateway/Server/Middleware/UserInfo.ts
@@ -122,6 +122,7 @@ class UserInfoProxyMiddleware {
 
         try {
             let dhRes = await axios.request(options);
+
             if (dhRes.status == 200) {
                 return res.json(dhRes.data)
             } else {

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -184,11 +184,11 @@ class AdrGateway {
             this.consumerDataAccess.handler('/cds-au/v1/banking/payments/scheduled','bank:regular_payments:read')
         )
 
-        app.get("/cdr/consents/:consentId/banking/payees",
+        app.get("/cdr/consents/:consentId/payees",
             this.consumerDataAccess.handler('/cds-au/v1/banking/payees','bank:payees:read')
         )
 
-        app.get("/cdr/consents/:consentId/banking/payees/:payeeId",
+        app.get("/cdr/consents/:consentId/payees/:payeeId",
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/payees/${p.payeeId}`,'bank:payees:read')
         )
 
@@ -207,11 +207,6 @@ class AdrGateway {
         /** TODO
          * Endpoints yet to implement
          * * GET /discovery/outages
-         * * GET /banking/accounts/{accountId}/payments/scheduled
-         * * GET /banking/payments/scheduled
-         * * POST /banking/payments/scheduled
-         * * GET /banking/payees
-         * * GET /banking/payees/{payeeId}
          * * GET /banking/products
          * * GET /banking/products/{productId}
          */

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -151,6 +151,10 @@ class AdrGateway {
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/direct-debits`,'bank:regular_payments:read')
         )
 
+        app.get("/cdr/consents/:consentId/accounts/:accountId/direct-debits",
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/direct-debits`,'bank:regular_payments:read')
+        )
+
         app.get("/cdr/consents/:consentId/accounts/:accountId/balance",
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/balance`,'bank:accounts.basic:read')
         )
@@ -182,8 +186,6 @@ class AdrGateway {
         /** TODO
          * Endpoints yet to implement
          * * GET /discovery/outages
-         * * GET /banking/accounts/{accountId}/direct-debits
-         * * POST /banking/accounts/direct-debits
          * * GET /banking/accounts/{accountId}/payments/scheduled
          * * GET /banking/payments/scheduled
          * * POST /banking/payments/scheduled

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -171,6 +171,19 @@ class AdrGateway {
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/transactions/${p.transactionId}`,'bank:transactions:read')
         )
 
+        app.get("/cdr/consents/:consentId/accounts/:accountId/payments/scheduled",
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/payments/scheduled`,'bank:regular_payments:read')
+        )
+
+        app.get("/cdr/consents/:consentId/payments/scheduled",
+            this.consumerDataAccess.handler('/cds-au/v1/banking/payments/scheduled','bank:regular_payments:read')
+        )
+
+        app.post("/cdr/consents/:consentId/payments/scheduled",
+            bodyParser.json(),
+            this.consumerDataAccess.handler('/cds-au/v1/banking/payments/scheduled','bank:regular_payments:read')
+        )
+
         app.get("/cdr/consents/:consentId/consumerInfo",
             this.consumerDataAccess.handler('/cds-au/v1/common/customer','common:customer.basic:read')
         )

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -142,6 +142,10 @@ class AdrGateway {
             this.consumerDataAccess.handler('/cds-au/v1/banking/accounts/balances','bank:accounts.basic:read')
         )
 
+        app.get("/cdr/consents/:consentId/accounts/direct-debits",
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/direct-debits`,'bank:regular_payments:read')
+        )
+
         app.get("/cdr/consents/:consentId/accounts/:accountId/balance",
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/balance`,'bank:accounts.basic:read')
         )
@@ -154,14 +158,36 @@ class AdrGateway {
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/transactions`,'bank:transactions:read')
         )
 
+        app.get("/cdr/consents/:consentId/accounts/:accountId/transactions/:transactionId",
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/transactions/${p.transactionId}`,'bank:transactions:read')
+        )
+
         app.get("/cdr/consents/:consentId/consumerInfo",
             this.consumerDataAccess.handler('/cds-au/v1/common/customer','common:customer.basic:read')
+        )
+
+        app.get("/cdr/consents/:consentId/consumerInfo/detail",
+            this.consumerDataAccess.handler('/cds-au/v1/common/customer/detail','common:customer.detail:read')
         )
 
         app.get("/cdr/consents/:consentId/userInfo",
             this.userInfo.handler()
         );
-      
+
+        /** TODO
+         * Endpoints yet to implement
+         * * GET /discovery/outages
+         * * GET /banking/accounts/{accountId}/direct-debits
+         * * POST /banking/accounts/direct-debits
+         * * GET /banking/accounts/{accountId}/payments/scheduled
+         * * GET /banking/payments/scheduled
+         * * POST /banking/payments/scheduled
+         * * GET /banking/payees
+         * * GET /banking/payees/{payeeId}
+         * * GET /banking/products
+         * * GET /banking/products/{productId}
+         */
+
         // Test hook
         (<any>app).connector = this.connector;
 

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -146,6 +146,11 @@ class AdrGateway {
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/direct-debits`,'bank:regular_payments:read')
         )
 
+        app.post("/cdr/consents/:consentId/accounts/direct-debits",
+            bodyParser.json(),
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/direct-debits`,'bank:regular_payments:read')
+        )
+
         app.get("/cdr/consents/:consentId/accounts/:accountId/balance",
             this.consumerDataAccess.handler(p => `/cds-au/v1/banking/accounts/${p.accountId}/balance`,'bank:accounts.basic:read')
         )

--- a/src/AdrGateway/Server/server.ts
+++ b/src/AdrGateway/Server/server.ts
@@ -184,6 +184,14 @@ class AdrGateway {
             this.consumerDataAccess.handler('/cds-au/v1/banking/payments/scheduled','bank:regular_payments:read')
         )
 
+        app.get("/cdr/consents/:consentId/banking/payees",
+            this.consumerDataAccess.handler('/cds-au/v1/banking/payees','bank:payees:read')
+        )
+
+        app.get("/cdr/consents/:consentId/banking/payees/:payeeId",
+            this.consumerDataAccess.handler(p => `/cds-au/v1/banking/payees/${p.payeeId}`,'bank:payees:read')
+        )
+
         app.get("/cdr/consents/:consentId/consumerInfo",
             this.consumerDataAccess.handler('/cds-au/v1/common/customer','common:customer.basic:read')
         )

--- a/src/AdrGateway/Server/start.ts
+++ b/src/AdrGateway/Server/start.ts
@@ -1,3 +1,6 @@
+import {loadInstrumentation} from "./Instrumentation"
+loadInstrumentation();
+
 import "reflect-metadata"
 
 import { GetBackendConfig } from "../Config";

--- a/src/Common/Axios/axios.ts
+++ b/src/Common/Axios/axios.ts
@@ -5,7 +5,6 @@ import {Agent as httpAgent}  from "http"
 import https from "https"
 import URLParse from "url-parse"
 import tls from "tls"
-import { requestFormatter, responseFormatter } from "../LogReplacers"
 
 interface MtlsOptions {
     ca?: any,
@@ -118,7 +117,6 @@ const axiosClient = (() => {
     })
 
     client.interceptors.request.use(config => {
-
         // use the https proxy for non-localhost addresses
         let mtlsConfig = <MtlsOptions>_.pick(config.httpsAgent.options,'ca','cert','key');
 
@@ -142,6 +140,7 @@ const axiosClient = (() => {
         let {http,https} = createTunnelAgents(proxyOptions,mtlsConfig);
         config.httpAgent = http;
         config.httpsAgent = https;
+
         return config;
 
     })

--- a/src/Common/Connectivity/Connector.generated.ts
+++ b/src/Common/Connectivity/Connector.generated.ts
@@ -33,9 +33,9 @@ export class DefaultConnector {
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfigs,{  }, _.merge({maxHealingIterations: 0},$)),
     GetWithHealing: ($?: Types.GetOpts<Types.IndexedSoftwareProductConfigs>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfigs,{  }, $)
   })
-  public SoftwareProductConfig = (SoftwareProductKey: Types.StringOrUndefined, SoftwareProductId: Types.StringOrUndefined) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfig,{ SoftwareProductKey, SoftwareProductId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.SoftwareProductConnectivityConfig>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfig,{ SoftwareProductKey, SoftwareProductId }, $)
+  public SoftwareProductConfig = (SoftwareProductId: Types.StringOrUndefined) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfig,{ SoftwareProductId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.SoftwareProductConnectivityConfig>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductConfig,{ SoftwareProductId }, $)
   })
   public DataRecipientJwks = () => ({
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DataRecipientJwks,{  }, _.merge({maxHealingIterations: 0},$)),
@@ -53,13 +53,13 @@ export class DefaultConnector {
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertDataRecipientIsActive,{  }, _.merge({maxHealingIterations: 0},$)),
     GetWithHealing: ($?: Types.GetOpts<void>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertDataRecipientIsActive,{  }, $)
   })
-  public SoftwareProductStatus = (SoftwareProductKey: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductStatus,{ SoftwareProductKey }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<string>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductStatus,{ SoftwareProductKey }, $)
+  public SoftwareProductStatus = (SoftwareProductId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductStatus,{ SoftwareProductId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<string>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareProductStatus,{ SoftwareProductId }, $)
   })
-  public AssertSoftwareProductStatusIsActive = (SoftwareProductKey: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertSoftwareProductStatusIsActive,{ SoftwareProductKey }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<void>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertSoftwareProductStatusIsActive,{ SoftwareProductKey }, $)
+  public AssertSoftwareProductStatusIsActive = (SoftwareProductId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertSoftwareProductStatusIsActive,{ SoftwareProductId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<void>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.AssertSoftwareProductStatusIsActive,{ SoftwareProductId }, $)
   })
   public RegisterAccessCredentials = () => ({
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.RegisterAccessCredentials,{  }, _.merge({maxHealingIterations: 0},$)),
@@ -101,33 +101,33 @@ export class DefaultConnector {
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DataHolderRevocationJwks,{ DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
     GetWithHealing: ($?: Types.GetOpts<Types.JWKS.KeyStore>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DataHolderRevocationJwks,{ DataHolderBrandId }, $)
   })
-  public SoftwareStatementAssertion = (SoftwareProductKey: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareStatementAssertion,{ SoftwareProductKey }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<string>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareStatementAssertion,{ SoftwareProductKey }, $)
+  public SoftwareStatementAssertion = (SoftwareProductId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareStatementAssertion,{ SoftwareProductId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<string>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.SoftwareStatementAssertion,{ SoftwareProductId }, $)
   })
-  public CurrentClientRegistration = (SoftwareProductKey: string, DataHolderBrandId: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CurrentClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CurrentClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, $)
+  public CurrentClientRegistration = (SoftwareProductId: string, DataHolderBrandId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CurrentClientRegistration,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CurrentClientRegistration,{ SoftwareProductId, DataHolderBrandId }, $)
   })
-  public DhNewClientRegistration = (SoftwareProductKey: string, DataHolderBrandId: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhNewClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhNewClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, $)
+  public DhNewClientRegistration = (SoftwareProductId: string, DataHolderBrandId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhNewClientRegistration,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhNewClientRegistration,{ SoftwareProductId, DataHolderBrandId }, $)
   })
-  public BootstrapClientRegistration = (SoftwareProductKey: string, DataHolderBrandId: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.BootstrapClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.BootstrapClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, $)
+  public BootstrapClientRegistration = (SoftwareProductId: string, DataHolderBrandId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.BootstrapClientRegistration,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.BootstrapClientRegistration,{ SoftwareProductId, DataHolderBrandId }, $)
   })
-  public DhRegAccessToken = (SoftwareProductKey: string, DataHolderBrandId: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhRegAccessToken,{ SoftwareProductKey, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.AccessToken>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhRegAccessToken,{ SoftwareProductKey, DataHolderBrandId }, $)
+  public DhRegAccessToken = (SoftwareProductId: string, DataHolderBrandId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhRegAccessToken,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.AccessToken>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhRegAccessToken,{ SoftwareProductId, DataHolderBrandId }, $)
   })
   public DhDeleteClientRegistration = (SoftwareProductId: string, DataHolderBrandId: string) => ({
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhDeleteClientRegistration,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
     GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.DhDeleteClientRegistration,{ SoftwareProductId, DataHolderBrandId }, $)
   })
-  public CheckAndUpdateClientRegistration = (SoftwareProductKey: string, DataHolderBrandId: string) => ({
-    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CheckAndUpdateClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
-    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CheckAndUpdateClientRegistration,{ SoftwareProductKey, DataHolderBrandId }, $)
+  public CheckAndUpdateClientRegistration = (SoftwareProductId: string, DataHolderBrandId: string) => ({
+    Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CheckAndUpdateClientRegistration,{ SoftwareProductId, DataHolderBrandId }, _.merge({maxHealingIterations: 0},$)),
+    GetWithHealing: ($?: Types.GetOpts<Types.DataHolderRegistration>) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.CheckAndUpdateClientRegistration,{ SoftwareProductId, DataHolderBrandId }, $)
   })
   public GetAuthorizationRequest = (ConsentRequestParams: Types.ConsentRequestParams) => ({
     Evaluate: ($?: Types.EvalOpts) => new CommsDependencyEvaluator(this.cache, this.graph.logger).get(this.graph.Dependencies.GetAuthorizationRequest,{ ConsentRequestParams }, _.merge({maxHealingIterations: 0},$)),

--- a/src/Common/Connectivity/Dependencies.yml
+++ b/src/Common/Connectivity/Dependencies.yml
@@ -11,7 +11,6 @@ SoftwareProductConfigs:
 
 SoftwareProductConfig:
   parameters:
-    SoftwareProductKey: Types.StringOrUndefined
     SoftwareProductId: Types.StringOrUndefined
   dependencies:
     - SoftwareProductConfigs
@@ -49,7 +48,7 @@ AssertDataRecipientIsActive:
 
 SoftwareProductStatus:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
   output: string
   dependencies:
     - AdrConnectivityConfig
@@ -59,7 +58,7 @@ SoftwareProductStatus:
 
 AssertSoftwareProductStatusIsActive:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
   dependencies:
     - SoftwareProductStatus
     - SoftwareProductConfig
@@ -167,7 +166,7 @@ DataHolderRevocationJwks:
 
 SoftwareStatementAssertion:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
   dependencies:
     - SoftwareProductConfig
     - AdrConnectivityConfig
@@ -179,7 +178,7 @@ SoftwareStatementAssertion:
 
 CurrentClientRegistration:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
     DataHolderBrandId: string
   dependencies:
     - SoftwareProductConfig
@@ -190,7 +189,7 @@ CurrentClientRegistration:
 
 DhNewClientRegistration: 
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
     DataHolderBrandId: string
   dependencies:
     - AdrConnectivityConfig
@@ -206,7 +205,7 @@ DhNewClientRegistration:
 
 BootstrapClientRegistration:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
     DataHolderBrandId: string
   dependencies:
     - AssertSoftwareProductStatusIsActive
@@ -219,7 +218,7 @@ BootstrapClientRegistration:
 
 DhRegAccessToken:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
     DataHolderBrandId: string
   dependencies:
     - DataRecipientJwks
@@ -248,7 +247,7 @@ DhDeleteClientRegistration:
 
 CheckAndUpdateClientRegistration:
   parameters:
-    SoftwareProductKey: string
+    SoftwareProductId: string
     DataHolderBrandId: string
   dependencies:
     - AssertSoftwareProductStatusIsActive
@@ -268,7 +267,7 @@ GetAuthorizationRequest:
   parameters:
     ConsentRequestParams: Types.ConsentRequestParams
   project:
-    SoftwareProductKey: $ => $.ConsentRequestParams.productKey
+    SoftwareProductId: $ => $.ConsentRequestParams.softwareProductId
     DataHolderBrandId: $ => $.ConsentRequestParams.dataholderBrandId
   preassertions:
     - AssertSoftwareProductStatusIsActive

--- a/src/Common/Connectivity/DependencyGraph.generated.ts
+++ b/src/Common/Connectivity/DependencyGraph.generated.ts
@@ -56,11 +56,10 @@ export class DependencyGraph {
       cacheTrail: [],
     })
 
-    const SoftwareProductConfig = new Dependency<{SoftwareProductKey: Types.StringOrUndefined, SoftwareProductId: Types.StringOrUndefined}, {SoftwareProductConfigs: Types.IndexedSoftwareProductConfigs}, Types.SoftwareProductConnectivityConfig>({
+    const SoftwareProductConfig = new Dependency<{SoftwareProductId: Types.StringOrUndefined}, {SoftwareProductConfigs: Types.IndexedSoftwareProductConfigs}, Types.SoftwareProductConnectivityConfig>({
       name: "SoftwareProductConfig",
       evaluator: util.GetSoftwareProductConfig,
       parameters: {
-        SoftwareProductKey:Identifiers.Types.StringOrUndefined,
         SoftwareProductId:Identifiers.Types.StringOrUndefined
       },
       dependencies: [
@@ -125,11 +124,11 @@ export class DependencyGraph {
       },
     })
 
-    const SoftwareProductStatus = new Dependency<{SoftwareProductKey: string}, {AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig}, string>({
+    const SoftwareProductStatus = new Dependency<{SoftwareProductId: string}, {AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig}, string>({
       name: "SoftwareProductStatus",
       evaluator: util.SoftwareProductStatus.bind(undefined,factory.cert),
       parameters: {
-        SoftwareProductKey:Identifiers.string
+        SoftwareProductId:Identifiers.string
       },
       dependencies: [
         AdrConnectivityConfig,
@@ -142,11 +141,11 @@ export class DependencyGraph {
       },
     })
 
-    const AssertSoftwareProductStatusIsActive = new Dependency<{SoftwareProductKey: string}, {SoftwareProductStatus: string, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig}, void>({
+    const AssertSoftwareProductStatusIsActive = new Dependency<{SoftwareProductId: string}, {SoftwareProductStatus: string, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig}, void>({
       name: "AssertSoftwareProductStatusIsActive",
       evaluator: util.AssertSoftwareProductActive,
       parameters: {
-        SoftwareProductKey:Identifiers.string
+        SoftwareProductId:Identifiers.string
       },
       dependencies: [
         SoftwareProductStatus,
@@ -330,12 +329,12 @@ export class DependencyGraph {
       serializer: Serial.JWKS,
     })
 
-    const SoftwareStatementAssertion = new Dependency<{SoftwareProductKey: string}, {SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, AdrConnectivityConfig: Types.AdrConnectivityConfig, RegisterAccessCredentials: Types.AccessToken}, string>({
+    const SoftwareStatementAssertion = new Dependency<{SoftwareProductId: string}, {SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, AdrConnectivityConfig: Types.AdrConnectivityConfig, RegisterAccessCredentials: Types.AccessToken}, string>({
       name: "SoftwareStatementAssertion",
       evaluator: util.RegisterGetSSA.bind(undefined,factory.cert),
       validator: util.Validation.ValidAndCurrentSSA,
       parameters: {
-        SoftwareProductKey:Identifiers.string
+        SoftwareProductId:Identifiers.string
       },
       dependencies: [
         SoftwareProductConfig,
@@ -350,11 +349,11 @@ export class DependencyGraph {
       },
     })
 
-    const CurrentClientRegistration = new Dependency<{SoftwareProductKey: string, DataHolderBrandId: string}, {SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataHolderBrandMetadata: Types.DataHolderRegisterMetadata}, Types.DataHolderRegistration>({
+    const CurrentClientRegistration = new Dependency<{SoftwareProductId: string, DataHolderBrandId: string}, {SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataHolderBrandMetadata: Types.DataHolderRegisterMetadata}, Types.DataHolderRegistration>({
       name: "CurrentClientRegistration",
       evaluator: util.GetCurrentClientRegistration.bind(undefined,factory.dataholderRegistrationManager),
       parameters: {
-        SoftwareProductKey:Identifiers.string,
+        SoftwareProductId:Identifiers.string,
         DataHolderBrandId:Identifiers.string
       },
       dependencies: [
@@ -368,11 +367,11 @@ export class DependencyGraph {
       },
     })
 
-    const DhNewClientRegistration = new Dependency<{SoftwareProductKey: string, DataHolderBrandId: string}, {AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, DataHolderBrandMetadata: Types.DataHolderRegisterMetadata, DataHolderUpAndReady: void, SoftwareStatementAssertion: string}, Types.DataHolderRegistration>({
+    const DhNewClientRegistration = new Dependency<{SoftwareProductId: string, DataHolderBrandId: string}, {AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, DataHolderBrandMetadata: Types.DataHolderRegisterMetadata, DataHolderUpAndReady: void, SoftwareStatementAssertion: string}, Types.DataHolderRegistration>({
       name: "DhNewClientRegistration",
       evaluator: util.NewClientRegistration.bind(undefined,factory.cert,factory.dataholderRegistrationManager),
       parameters: {
-        SoftwareProductKey:Identifiers.string,
+        SoftwareProductId:Identifiers.string,
         DataHolderBrandId:Identifiers.string
       },
       dependencies: [
@@ -391,11 +390,11 @@ export class DependencyGraph {
       },
     })
 
-    const BootstrapClientRegistration = new Dependency<{SoftwareProductKey: string, DataHolderBrandId: string}, {AssertSoftwareProductStatusIsActive: void, CurrentClientRegistration: Types.DataHolderRegistration, DhNewClientRegistration?: Types.DataHolderRegistration}, Types.DataHolderRegistration>({
+    const BootstrapClientRegistration = new Dependency<{SoftwareProductId: string, DataHolderBrandId: string}, {AssertSoftwareProductStatusIsActive: void, CurrentClientRegistration: Types.DataHolderRegistration, DhNewClientRegistration?: Types.DataHolderRegistration}, Types.DataHolderRegistration>({
       name: "BootstrapClientRegistration",
       evaluator: $ => $.CurrentClientRegistration || $.DhNewClientRegistration || (() => {throw new Error('Could not bootstrap client registration')})(),
       parameters: {
-        SoftwareProductKey:Identifiers.string,
+        SoftwareProductId:Identifiers.string,
         DataHolderBrandId:Identifiers.string
       },
       dependencies: [
@@ -410,11 +409,11 @@ export class DependencyGraph {
       },
     })
 
-    const DhRegAccessToken = new Dependency<{SoftwareProductKey: string, DataHolderBrandId: string}, {DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, BootstrapClientRegistration: Types.DataHolderRegistration}, Types.AccessToken>({
+    const DhRegAccessToken = new Dependency<{SoftwareProductId: string, DataHolderBrandId: string}, {DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, BootstrapClientRegistration: Types.DataHolderRegistration}, Types.AccessToken>({
       name: "DhRegAccessToken",
       evaluator: util.GetDataHolderRegistrationAccessToken.bind(undefined,factory.cert),
       parameters: {
-        SoftwareProductKey:Identifiers.string,
+        SoftwareProductId:Identifiers.string,
         DataHolderBrandId:Identifiers.string
       },
       dependencies: [
@@ -454,11 +453,11 @@ export class DependencyGraph {
       },
     })
 
-    const CheckAndUpdateClientRegistration = new Dependency<{SoftwareProductKey: string, DataHolderBrandId: string}, {AssertSoftwareProductStatusIsActive: void, AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, DataHolderUpAndReady: void, SoftwareStatementAssertion: string, BootstrapClientRegistration: Types.DataHolderRegistration, DhRegAccessToken: Types.AccessToken}, Types.DataHolderRegistration>({
+    const CheckAndUpdateClientRegistration = new Dependency<{SoftwareProductId: string, DataHolderBrandId: string}, {AssertSoftwareProductStatusIsActive: void, AdrConnectivityConfig: Types.AdrConnectivityConfig, SoftwareProductConfig: Types.SoftwareProductConnectivityConfig, DataRecipientJwks: Types.JWKS.KeyStore, DataHolderOidc: Types.DataholderOidcResponse, DataHolderUpAndReady: void, SoftwareStatementAssertion: string, BootstrapClientRegistration: Types.DataHolderRegistration, DhRegAccessToken: Types.AccessToken}, Types.DataHolderRegistration>({
       name: "CheckAndUpdateClientRegistration",
       evaluator: util.CheckAndUpdateClientRegistration.bind(undefined,factory.cert,factory.dataholderRegistrationManager),
       parameters: {
-        SoftwareProductKey:Identifiers.string,
+        SoftwareProductId:Identifiers.string,
         DataHolderBrandId:Identifiers.string
       },
       dependencies: [
@@ -492,7 +491,7 @@ export class DependencyGraph {
         ConsentRequestParams:Identifiers.Types.ConsentRequestParams
       },
       project: {
-        SoftwareProductKey:$ => $.ConsentRequestParams.productKey,
+        SoftwareProductId:$ => $.ConsentRequestParams.softwareProductId,
         DataHolderBrandId:$ => $.ConsentRequestParams.dataholderBrandId,
       },
       dependencies: [

--- a/src/Common/Connectivity/Evaluators/AuthorizationRequest.ts
+++ b/src/Common/Connectivity/Evaluators/AuthorizationRequest.ts
@@ -16,6 +16,7 @@ export interface ConsentRequestParams {
   dataholderBrandId: string,
   productKey: string,
   redirectUri?: string,
+  softwareProductId: string,
   additionalClaims?: AdrConnectivityConfig["DefaultClaims"]
 }
 

--- a/src/Common/Connectivity/Evaluators/AuthorizationRequest.ts
+++ b/src/Common/Connectivity/Evaluators/AuthorizationRequest.ts
@@ -15,6 +15,7 @@ export interface ConsentRequestParams {
   scopes: string[],
   dataholderBrandId: string,
   productKey: string,
+  redirectUri?: string,
   additionalClaims?: AdrConnectivityConfig["DefaultClaims"]
 }
 
@@ -44,7 +45,8 @@ export const GetAuthorizationRequest = async (cert:ClientCertificateInjector,con
       id_token: _.merge($.AdrConnectivityConfig.DefaultClaims?.id_token, p.additionalClaims?.id_token)
   }
 
-  let redirectUri = $.SoftwareProductConfig.redirect_uris[0];
+  let redirectUri = $.ConsentRequestParams.redirectUri || $.SoftwareProductConfig.redirect_uris[0];
+  //let redirectUri = $.SoftwareProductConfig.redirect_uris[0];
 
   // Get a request URL
   let authUrl = await getAuthPostGetRequestUrl(cert,{

--- a/src/Common/Connectivity/Evaluators/DataHolderJwks.ts
+++ b/src/Common/Connectivity/Evaluators/DataHolderJwks.ts
@@ -28,12 +28,13 @@ export const GetDataHolderRevocationJwks = async (cert: ClientCertificateInjecto
             responseType: "json",
             timeout: 10000
         })
+
         axios.request(options).then(value => { // TODO configure timeout value
             resolve(value.data)
         }, err => {
             reject(err)
         })
-    })))
+})))
 
     let aggregated = { keys: _.flatten(jwksObjs.map(j => j.keys)) }
 

--- a/src/Common/Connectivity/Evaluators/DynamicClientRegistration.ts
+++ b/src/Common/Connectivity/Evaluators/DynamicClientRegistration.ts
@@ -40,7 +40,9 @@ export const GetDataHolderRegistrationAccessToken = async (cert:ClientCertificat
           client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
       })
   }
+
   let response = await axios.request(cert.inject(options));
+
   return new AccessToken(response.data.access_token,response.data.expires_in);
 }
 
@@ -170,7 +172,9 @@ const NewRegistrationAtDataholder = async (cert:ClientCertificateInjector, $: {
   let registrationRequestJwt = JWT.sign(registrationRequest,$.DataRecipientJwks.get({alg:'PS256',use:'sig'}),{header:{typ:"JWT"}})
 
   let options = cert.inject({method:"POST", url: $.DataHolderOidc.registration_endpoint, responseType: "json", data: registrationRequestJwt, headers: {"content-type":"application/jwt"}});
+
   let responseRaw = await axios.request(options)
+
   let response:DataholderRegistrationResponse = responseRaw.data;
 
   return response;
@@ -191,8 +195,9 @@ const DeleteRegistrationAtDataholder = async (cert:ClientCertificateInjector, $:
     headers: {Authorization: `Bearer ${$.DhRegAccessToken.accessToken}`}
   });
   try {
-    await axios.request(options)
-  } catch (err) {
+    let response = await axios.request(options)
+  
+    } catch (err) {
     throw `Expected 204 from DELETE registration endpoint but received ${err.response.status}`;
   }  
 

--- a/src/Common/Connectivity/Evaluators/FetchTokens.ts
+++ b/src/Common/Connectivity/Evaluators/FetchTokens.ts
@@ -47,7 +47,7 @@ export const SyncRefreshTokenStatus = async (consentManager:ConsentRequestLogMan
     }
 
     let response:AxiosResponse<{active:boolean}> = await axios.request(cert.inject(options));
-
+  
     if (!response.data.active) {
         await consentManager.RevokeConsent($.Consent,"DataHolder");
         return {
@@ -93,6 +93,7 @@ export const FetchTokens = async (logger: winston.Logger, cert: ClientCertificat
 
     cert.inject(options);
     const tokenRequestTime = moment.utc().toDate();
+
     let response = await axios.request(options);
 
     let responseObject: Types.TokenResponse = response.data;

--- a/src/Common/Connectivity/Evaluators/PropagateRevokedConsent.ts
+++ b/src/Common/Connectivity/Evaluators/PropagateRevokedConsent.ts
@@ -38,6 +38,7 @@ export const PropagateRevokedConsent = async (logger: winston.Logger, cert: Clie
     }
 
     cert.inject(options);
+
     let response = await axios.request(options);
 
     if (!response.status.toString().startsWith("2")) throw 'Revocation was not successful'
@@ -57,6 +58,7 @@ export const PropagateRevokedConsent = async (logger: winston.Logger, cert: Clie
     }
 
     cert.inject(options);
+
     let response = await axios.request(options);
 
     if (!response.status.toString().startsWith("2")) throw 'Revocation was not successful'

--- a/src/Common/Connectivity/Evaluators/RegisterAccessToken.ts
+++ b/src/Common/Connectivity/Evaluators/RegisterAccessToken.ts
@@ -27,6 +27,8 @@ export const GetRegisterAccessToken = async (cert:ClientCertificateInjector, par
           client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
       })
   }
+
   let response = await axios.request(cert.inject(<any>options));
+
   return new AccessToken(response.data.access_token,response.data.expires_in);
 }

--- a/src/Common/Connectivity/Evaluators/SoftwareProductConfig.ts
+++ b/src/Common/Connectivity/Evaluators/SoftwareProductConfig.ts
@@ -32,12 +32,10 @@ export const GetSoftwareProductConfigs = (async ({AdrConnectivityConfig}:{AdrCon
   return {byKey,byId};
 });
 
-export const GetSoftwareProductConfig = async ($:{SoftwareProductConfigs: IndexedSoftwareProductConfigs, SoftwareProductKey?:string, SoftwareProductId?:string}):Promise<Types.SoftwareProductConnectivityConfig> => {
-  if (typeof $.SoftwareProductKey == "string") {
-    return $.SoftwareProductConfigs.byKey[$.SoftwareProductKey]
-  } else if (typeof $.SoftwareProductId == "string") {
+export const GetSoftwareProductConfig = async ($:{SoftwareProductConfigs: IndexedSoftwareProductConfigs, SoftwareProductId:string}):Promise<Types.SoftwareProductConnectivityConfig> => {
+  if (typeof $.SoftwareProductId == "string") {
     return $.SoftwareProductConfigs.byId[$.SoftwareProductId]
   } else {
-    throw 'Must supply a SoftwareProductId or SoftwareProductKey as a parameter'
+    throw 'Must supply a SoftwareProductId as a parameter'
   }
 };

--- a/src/Common/Connectivity/Evaluators/UserInfo.ts
+++ b/src/Common/Connectivity/Evaluators/UserInfo.ts
@@ -21,6 +21,8 @@ export const GetUserInfo = async (clientCertInjector:ClientCertificateInjector, 
     }
 
     clientCertInjector.inject(options);
-    let response:Types.UserInfoResponse = (await axios.request(options)).data;
-    return response
+
+    let response = (await axios.request(options)).data;
+
+    return <Types.UserInfoResponse>response
 }

--- a/src/Common/SecurityProfile/Scope.ts
+++ b/src/Common/SecurityProfile/Scope.ts
@@ -4,7 +4,7 @@ enum CdsScope {
     BankAccountsDetailRead="bank:accounts.detail:read",
     BankTransactionsRead="bank:transactions:read",
     BankPayeesRead="bank:payees:read",
-    BankRegularPaymentsTead="bank:regular_payments:read",
+    BankRegularPaymentsRead="bank:regular_payments:read",
     CommonCustomerBasicRead="common:customer.basic:read",
     CommonCustomerDetailRead="common:customer.detail:read"
 }

--- a/src/Common/Server/Middleware/Pagination.ts
+++ b/src/Common/Server/Middleware/Pagination.ts
@@ -148,7 +148,8 @@ class PaginationMiddleware {
             }
     
             if (!(<any>res).responseData) {
-                return res.status(404).send();
+                console.error('No response data found while trying to wrap the data', res)
+                return res.status(500).send();
             }
 
             const result = {

--- a/src/HttpsProxy/Config.ts
+++ b/src/HttpsProxy/Config.ts
@@ -59,7 +59,7 @@ export const GetConfig = (configFile?:string):MockInfrastructureConfig => {
                 },
                 DhServerMtlsPublicProtected: {
                     users: { "dh-user": "dh-password" },
-                    noAuthPattern: /^(GET|POST) \//
+                    noAuthPattern: /^(GET|POST|PUT) \//
                 }
             },
             env: 'MOCK_INFRASTRUCTURE_PROXY_ROUTES'

--- a/src/MockServices/DhServer/Server/Handlers/PushedAuthorizationRequest.ts
+++ b/src/MockServices/DhServer/Server/Handlers/PushedAuthorizationRequest.ts
@@ -43,7 +43,9 @@ export class PushedAuthorizationRequestMiddleware {
             let params:{
                 request: string
                 client_id: string,
-                client_assertion: string
+                client_assertion: string,
+                scope?: string,
+                response_type?: string
             } = <any>matchedData(req)
 
             // TODO move this client credntial check to an auth middleware
@@ -83,7 +85,15 @@ export class PushedAuthorizationRequestMiddleware {
             } catch (e) {
                 return res.status(401).json({error:"invalid_client"})
             }
-            
+
+            if (typeof params.scope !== "string" || params.scope !== requestObject.scope) {
+                return res.status(401).json({error:"invalid_request"});
+            }
+
+            if (typeof params.response_type !== "string" || params.response_type !== requestObject.response_type) {
+                return res.status(401).json({error:"invalid_request"});
+            }
+
             const request_uri = "par:"+uuid.v4();
 
             storedRequests[request_uri] = requestObject;
@@ -102,7 +112,9 @@ export class PushedAuthorizationRequestMiddleware {
             body("request").isJWT(),
             body("client_id").isString(),
             body('client_assertion_type').isString().equals("urn:ietf:params:oauth:client-assertion-type:jwt-bearer").withMessage("invalid client_assertion_type"),
-            body("client_assertion").isJWT()            
+            body("client_assertion").isJWT(),
+            body("scope").optional().isString(),
+            body("response_type").optional().isString()
         ],[
             <any>validationErrorMiddleware,
             Responder

--- a/src/MockServices/DhServer/TestData/ResourceData.ts
+++ b/src/MockServices/DhServer/TestData/ResourceData.ts
@@ -496,8 +496,10 @@ export const testTransactionList:BankAccountTransactionInternal[] = _.flatten(_.
                     payer: "Payer",
                     service: "X2P1.01",
                     extensionUType: "x2p101Payload",
-                    extendedDescription: `${r} - An extended message as sent by the payer, up to 250 characters.`,
-                    endToEndId: `abcd123${r}`
+                    x2p101Payload: {
+                        extendedDescription: `${r} - An extended message as sent by the payer, up to 250 characters.`,
+                        endToEndId: `abcd123${r}`
+                    }
                 }
             }
         }
@@ -508,8 +510,10 @@ export const testTransactionList:BankAccountTransactionInternal[] = _.flatten(_.
                     payee: "Payee",
                     service: "X2P1.01",
                     extensionUType: "x2p101Payload",
-                    extendedDescription: `${r} - An extended message as sent to the payee, up to 250 characters.`,
-                    endToEndId: `abcd123${r}`
+                    x2p101Payload: {
+                        extendedDescription: `${r} - An extended message as sent to the payee, up to 250 characters.`,
+                        endToEndId: `abcd123${r}`
+                    }
                 }
             }        
         }
@@ -554,7 +558,8 @@ export const GetTransactions = (subjectId:string, accountId: string) => {
 }
 
 export const TransactionDetail = (subjectId:string, accountId: string, transactionId: string) => {
-    if (!_.find(testAccountList, acc => acc.accountId == accountId)) {
+    let accountInt = _.find(testAccountList, acc => acc.accountId == accountId);
+    if (!accountInt) {
         throw new ConsumerForbiddenError("Account does not exist",{
             code: "NO_ACCOUNT",
             detail: "The account does not exist or is not consented",
@@ -574,6 +579,7 @@ export const TransactionDetail = (subjectId:string, accountId: string, transacti
     let detail = transactionInt._detail
 
     let transaction = _.merge(_.omit(transactionInt,'_detail'),detail)
+    transaction.accountId = accountInt.accountId;
 
     return transaction
 

--- a/src/MockServices/DhServer/TestData/ResourceData.ts
+++ b/src/MockServices/DhServer/TestData/ResourceData.ts
@@ -618,6 +618,114 @@ class GetAccountsRequest implements FilterableRequest {
     ]
 }
 
+enum BankingDomesticPayeeTypes {
+    Biller = 'BILLER',
+    Domestic = 'DOMESTIC',
+    International = 'INTERNATIONAL'
+}
+
+enum BankingPayeeDetailPayeeUTypes {
+    Biller = 'biller',
+    Domestic = 'domestic',
+    International = 'international'
+}
+
+interface BankingPayee {
+    payeeId: ASCIIString
+    nickname: string
+    description?: string
+    type: BankingDomesticPayeeTypes
+    creationDate: DateString
+    _detail: {
+        payeeUType: BankingPayeeDetailPayeeUTypes,
+        domestic?: BankingDomesticPayee,
+        biller?: BankingBillerPayee,
+        international?: BankingInternationalPayee
+    }
+}
+
+export const testPayeesList:BankingPayee[] = _.map(_.range(1,16),ind => {
+    let getType = ():BankingDomesticPayeeTypes => { switch(ind % (Object.keys(BankingDomesticPayeeTypes).length)) {
+        case 0: return BankingDomesticPayeeTypes.Biller; break;
+        case 1: return BankingDomesticPayeeTypes.Domestic; break;
+        case 2: return BankingDomesticPayeeTypes.International; break;
+        default: return BankingDomesticPayeeTypes.Domestic; break;
+    }};
+    let type = getType();
+
+    let getDetails = (type: BankingDomesticPayeeTypes) => {
+        switch(type) {
+            case BankingDomesticPayeeTypes.Biller:
+                return {
+                    payeeUType: BankingPayeeDetailPayeeUTypes.Biller,
+                    biller: {
+                        billerCode: "123456",
+                        crn: '987654321',
+                        billerName: 'Big Bad Biller'
+                    }
+                }
+            break;
+
+            case BankingDomesticPayeeTypes.Domestic:
+                return {
+                    payeeUType: BankingPayeeDetailPayeeUTypes.Domestic,
+                    domestic: {
+                        payeeAccountUType: BankingDomesticPayeeUTypes.Account,
+                        account: {
+                            accountName: 'J & J Smith',
+                            bsb: '012-345',
+                            accountNumber: '123456789'
+                        }
+                    }
+                }
+            break;
+
+            case BankingDomesticPayeeTypes.International:
+                return {
+                    payeeUType: BankingPayeeDetailPayeeUTypes.International,
+                    international: {
+                        beneficiaryDetails: {
+                            name: 'Kiwi Joe',
+                            country: 'NZ'
+                        },
+                        bankDetails: {
+                            country: 'NZ',
+                            accountNumber: '123456789'
+                        }
+                    }
+                }
+            break;
+
+            default:
+                throw "Unrecognised value for BankingDomesticPayeeTypes: " + type
+            break;
+        }
+    }
+
+    let payee = {
+        payeeId: `payee-${ind}`,
+        nickname: `payee-${ind}-nickname`,
+        description: `payee-description-${ind}`,
+        type: type,
+        creationDate: moment().subtract(5,'months').format('YYYY-MM-DD'),
+        _detail: getDetails(type)
+    }
+
+    return payee;
+})
+
+export const PayeeDetail = (subjectId:string, payeeId: string) => {
+    let payeeInt = _.find(testPayeesList, t => t.payeeId == payeeId)
+
+    let detail = payeeInt._detail
+
+    let payeeDetail = _.merge(_.omit(payeeInt,'_detail'),detail)
+
+    return payeeDetail
+
+}
+
+
 // results.ApplyFilter(new ProductCategoryAccountsFilter(ProductCategory.TRANS_AND_SAVINGS_ACCOUNTS),"productCategory")
 // results.ApplyFilter(ProductCategoryFilter,"openStatus",params["open-status"])
 // results.ApplyFilter(ProductCategoryFilter,"isOwned",params["is-owned"])

--- a/src/MockServices/DhServer/TestData/ResourceData.ts
+++ b/src/MockServices/DhServer/TestData/ResourceData.ts
@@ -464,7 +464,7 @@ export const testCustomerDetail = {
 export const testBalanceList:BankAccountBalance[] = _.map(testAccountDetailList,acc => ({
     accountId: acc.accountId,
     currentBalance: ((Math.random()-0.5)*5000).toFixed(2),
-    availableBalance: ((Math.random()-0.5)*5000).toFixed(2)
+    availableBalance: Math.abs(((Math.random()-0.5)*5000)).toFixed(2)
 }))
 
 const testAccountList:BankAccount[] = _.map(testAccountDetailList,det => _.pick(det,'accountId','displayName','nickname','isOwned','maskedNumber','productCategory','productName','consentStatus'));

--- a/src/MockServices/DhServer/TestData/ResourceData.ts
+++ b/src/MockServices/DhServer/TestData/ResourceData.ts
@@ -385,7 +385,10 @@ export const testScheduledPaymentsList:BankScheduledPayment[] = _.map(_.range(1,
             currency: 'AUD'
         }],
         recurrence: {
-            recurrenceUType: BankingScheduledPaymentRecurrenceUTypes.OnceOff
+            recurrenceUType: BankingScheduledPaymentRecurrenceUTypes.OnceOff,
+            onceOff: {
+                paymentDate: moment().add(1,'months').format('YYYY-MM-DD')
+            }
         }
     }
 

--- a/src/MockServices/DhServer/TestData/ResourceData.ts
+++ b/src/MockServices/DhServer/TestData/ResourceData.ts
@@ -104,6 +104,7 @@ interface BankDirectDebit {
     authorisedEntity: BankingAuthorisedEntity
     lastDebitDateTime: DateString
     lastDebitAmount: string
+    consentStatus: AccountConsentStatus
 }
 
 const padLeft = (n:number,width:number,decWidth=0,padChar='0') => {
@@ -172,7 +173,8 @@ export const testDirectDebitList:BankDirectDebit[] = _.map(_.range(1,6),ind => {
             arbn: (192837465*ind).toString()
         },
         lastDebitDateTime: moment().subtract(5,'months').format('YYYY-MM-DD'),
-        lastDebitAmount: "123.45"
+        lastDebitAmount: "123.45",
+        consentStatus: DetermineAccountConsentStatus(`account-${ind}`)
     }
 
     return directDebits;

--- a/src/MockServices/Register/MockData/DataHolders.ts
+++ b/src/MockServices/Register/MockData/DataHolders.ts
@@ -64,9 +64,147 @@ export const DataHolders = async (config:MockRegisterConfig,pw:DefaultConnector)
         "lastUpdated": moment().utc().toISOString()
     }
 
+    const realDhs = [
+        {
+          "dataHolderBrandId": "8c5bdd1b-aed9-40eb-8866-bfc5c1cfcae7",
+          "brandName": "Westpac",
+          "industry": "banking",
+          "logoUri": "https://banking.westpac.com.au/wbc/banking/Themes/Default/Desktop/WBC/Core/Images/logo_white_bg.png.6c772a263bf42d99a2c098bf0739fc5b504ed28d.png",
+          "legalEntity": {
+            "legalEntityId": "25017347-3adb-4fd6-8e73-dbec8d627cbe",
+            "legalEntityName": "Westpac Banking Corporation",
+            "logoUri": "https://banking.westpac.com.au/wbc/banking/Themes/Default/Desktop/WBC/Core/Images/logo_white_bg.png.ce5c4c19ec61b56796f0e218fc8329c558421fd8.png",
+            "abn": "33007457141",
+            "acn": "007457141"
+          },
+          "status": "ACTIVE",
+          "endpointDetail": {
+            "publicBaseUri": "https://digital-api.westpac.com.au/",
+            "resourceBaseUri": "https://cdr.api.westpac.com.au",
+            "infosecBaseUri": "https://cdr.idp.westpac.com.au/identity",
+            "websiteUri": "https://www.westpac.com.au/"
+          },
+          "authDetails": [
+            {
+              "registerUType": "SIGNED-JWT",
+              "jwksEndpoint": "https://idp.westpac.com.au/identity/ext/oauth/obdr_jwks"
+            }
+          ],
+          "lastUpdated": "2021-01-29T10:57:50Z"
+        },
+        {
+          "dataHolderBrandId": "89d926e2-78e8-4249-b92a-6c3d36839fe2",
+          "brandName": "NATIONAL AUSTRALIA BANK",
+          "industry": "banking",
+          "logoUri": "https://www.nab.com.au/etc/designs/nabrwd/clientlibs/images/logo.png",
+          "legalEntity": {
+            "legalEntityId": "9fc5dbfe-faf2-44ba-af92-9ab002b506f3",
+            "legalEntityName": "NATIONAL AUSTRALIA BANK LIMITED",
+            "logoUri": "https://www.nab.com.au/etc/designs/nabrwd/clientlibs/images/logo.png",
+            "abn": "12 004 044 937",
+            "acn": "004 044 9"
+          },
+          "status": "ACTIVE",
+          "endpointDetail": {
+            "publicBaseUri": "https://openbank.api.nab.com.au",
+            "resourceBaseUri": "https://openbank-secure.api.nab.com.au",
+            "infosecBaseUri": "https://openbank.api.nab.com.au",
+            "websiteUri": "https://developer.nab.com.au"
+          },
+          "authDetails": [
+            {
+              "registerUType": "SIGNED-JWT",
+              "jwksEndpoint": "https://openbank.api.nab.com.au/.well-known/keyset"
+            }
+          ],
+          "lastUpdated": "2021-03-02T06:05:16Z"
+        },
+        {
+          "dataHolderBrandId": "3150628b-cc24-40c6-be91-d599a1c35567",
+          "brandName": "ANZ",
+          "industry": "banking",
+          "logoUri": "https://www.anz.com.au/content/dam/anzcomau/logos/anz/ANZ-MB-Logo-3rd-Party-RGB.png",
+          "legalEntity": {
+            "legalEntityId": "73dadf05-5cf3-4135-8941-31f24a288df1",
+            "legalEntityName": "Australia and New Zealand Banking Group Limited",
+            "logoUri": "https://www.anz.com.au/content/dam/anzcomau/logos/anz/ANZ-MB-Logo-3rd-Party-RGB.png",
+            "abn": "11005357522",
+            "acn": "005357522"
+          },
+          "status": "ACTIVE",
+          "endpointDetail": {
+            "publicBaseUri": "https://api.anz",
+            "resourceBaseUri": "https://cdr.api.anz",
+            "infosecBaseUri": "https://unauth.cdr.api.anz",
+            "websiteUri": "https://www.anz.com.au"
+          },
+          "authDetails": [
+            {
+              "registerUType": "SIGNED-JWT",
+              "jwksEndpoint": "https://unauth.cdr.api.anz/cds-au/jwks"
+            }
+          ],
+          "lastUpdated": "2021-03-02T06:05:06Z"
+        },
+        {
+          "dataHolderBrandId": "7c356d3d-ff7d-49a5-b16e-3cffca4e49d3",
+          "brandName": "CommBank",
+          "industry": "banking",
+          "logoUri": "https://www.commbank.com.au/content/dam/commbank-assets/cba-stacked.jpg",
+          "legalEntity": {
+            "legalEntityId": "fc428f71-847c-4975-8dd6-e3f2cfdaafd0",
+            "legalEntityName": "Commonwealth Bank of Australia",
+            "logoUri": "https://www.commbank.com.au/content/dam/commbank-assets/cba-stacked.jpg",
+            "abn": "48123123124"
+          },
+          "status": "ACTIVE",
+          "endpointDetail": {
+            "publicBaseUri": "https://api.commbank.com.au/public",
+            "resourceBaseUri": "https://secure.api.commbank.com.au/api",
+            "infosecBaseUri": "https://api.commbank.com.au/infosec",
+            "websiteUri": "https://www.commbank.com.au"
+          },
+          "authDetails": [
+            {
+              "registerUType": "SIGNED-JWT",
+              "jwksEndpoint": "https://api.commbank.com.au/infosec/.well-known/openid-configuration/jwks"
+            }
+          ],
+          "lastUpdated": "2021-03-02T05:59:45Z"
+        },
+        {
+          "dataHolderBrandId": "bb91c794-e92e-4f9c-ba03-d83dea29fca7",
+          "brandName": "Regional Australia Bank",
+          "industry": "banking",
+          "logoUri": "https://www.regionalaustraliabank.com.au/-/media/CommunityMutual/Images/Logo/regional-australia-bank-primary-logo.png",
+          "legalEntity": {
+            "legalEntityId": "d4c2167c-03dc-4ba2-a03d-55aa34632e5e",
+            "legalEntityName": "Regional Australia Bank Ltd.",
+            "logoUri": "https://www.regionalaustraliabank.com.au/-/media/CommunityMutual/Images/Logo/regional-australia-bank-primary-logo.png",
+            "abn": "21087650360"
+          },
+          "status": "ACTIVE",
+          "endpointDetail": {
+            "publicBaseUri": "https://public-data.cdr.regaustbank.io",
+            "resourceBaseUri": "https://secured-data.cdr.regaustbank.io",
+            "infosecBaseUri": "https://idp.cdr.regionalaustraliabank.com.au/v1/rab-cdr",
+            "extensionBaseUri": "https://secured-data.cdr.regaustbank.io",
+            "websiteUri": "https://www.regionalaustraliabank.com.au/"
+          },
+          "authDetails": [
+            {
+              "registerUType": "SIGNED-JWT",
+              "jwksEndpoint": "https://idp.cdr.regionalaustraliabank.com.au/v1/rab-cdr/jwks"
+            }
+          ],
+          "lastUpdated": "2021-03-02T06:27:23Z"
+        }
+      ]
+      
+
 
     results.push([badBank,inactiveBank])
-
+    results.push(realDhs)
 
     return _.flatten(results);
 }

--- a/src/MockServices/Register/MockData/DataRecipients.ts
+++ b/src/MockServices/Register/MockData/DataRecipients.ts
@@ -30,7 +30,27 @@ const OriginalDataRecipients = [
                             "revocation_uri": "https://regaustbank.io/revocation",
                             "scope": "bank:accounts.basic:read bank:accounts.detail:read bank:transactions:read bank:payees:read bank:regular_payments:read common:customer.basic:read common:customer.detail:read cdr:registration"
                         }
+                    },
+                    {
+                        "softwareProductId": "test-data-recipient-1-brand-1-product-2",
+                        "softwareProductName": "Product 2",
+                        "logoUri": "string",
+                        "status": "ACTIVE",
+                        "ssaParticulars": {
+                            "client_description": "A mock software product for testing SSA",
+                            "client_uri": "https://regaustbank.io",
+                            "redirect_uris": [
+                                "https://raw.githubusercontent.com/Regional-Australia-Bank/ADR-Gateway/master/examples/redirect-uri.md",
+                                "https://regaustbank.io/redirect2"
+                            ],
+                            "tos_uri": "https://regaustbank.io/tos.html",
+                            "policy_uri": "https://regaustbank.io/policy.html",
+                            "jwks_uri": "https://regaustbank.io/jwks",
+                            "revocation_uri": "https://regaustbank.io/revocation",
+                            "scope": "bank:accounts.basic:read bank:accounts.detail:read bank:transactions:read bank:payees:read bank:regular_payments:read common:customer.basic:read common:customer.detail:read cdr:registration"
+                        }
                     }
+
                 ],
                 "status": "ACTIVE"
             }

--- a/src/Tests/EndToEnd/E2E-UAT-Scenarios.CdrRegister.ts
+++ b/src/Tests/EndToEnd/E2E-UAT-Scenarios.CdrRegister.ts
@@ -64,7 +64,9 @@ export const Tests = ((environment:E2ETestEnvironment) => {
             })
             .When(SetValue,async (ctx) => {
                 let connectivityConfig = (await environment.GetServiceDefinition.Connectivity())
-                let softwareProductConfig = await environment.TestServices.adrGateway.connectivity.SoftwareProductConfig("sandbox",undefined).Evaluate()
+
+                const softwareProductId = (await environment.TestServices.adrGateway.connectivity.SoftwareProductConfigs().Evaluate()).byKey["sandbox"].ProductId;
+                let softwareProductConfig = await environment.TestServices.adrGateway.connectivity.SoftwareProductConfig(softwareProductId).Evaluate()
 
                 let drs:any[] = (await (ctx.GetResult(DoRequest))).body.data
                 
@@ -261,7 +263,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                     }
                 })
                 .When(SetValue,async (ctx) => {
-                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProduct()).Evaluate({ignoreCache:"all"}).catch(logger.error)
+                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProductId()).Evaluate({ignoreCache:"all"}).catch(logger.error)
                 })
                 .Then(async ctx => {
                     let log = ctx.GetLastHttpRequest(undefined,/(token|ssa)$/)
@@ -283,7 +285,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                     }
                 })
                 .When(SetValue,async (ctx) => {
-                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProduct()).Evaluate({ignoreCache:"all"}).catch(logger.error)
+                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProductId()).Evaluate({ignoreCache:"all"}).catch(logger.error)
                 })
                 .Then(async ctx => {
                     let log = ctx.GetLastHttpRequest(undefined,/(token|ssa)$/)
@@ -305,7 +307,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                     }
                 })
                 .When(SetValue,async (ctx) => {
-                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProduct()).Evaluate({ignoreCache:"all"}).catch(logger.error)
+                    await ctx.environment.TestServices.adrGateway.connectivity.SoftwareStatementAssertion(await environment.OnlySoftwareProductId()).Evaluate({ignoreCache:"all"}).catch(logger.error)
                 })
                 .Then(async ctx => {
                     let log = ctx.GetLastHttpRequest(undefined,/(token|ssa)$/)

--- a/src/Tests/EndToEnd/E2E-UAT-Scenarios.DynamicClientRegistration.ts
+++ b/src/Tests/EndToEnd/E2E-UAT-Scenarios.DynamicClientRegistration.ts
@@ -233,7 +233,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                 logger.debug(`Test new client registration with dataholder ${dataholder}`)
 
                 // Expect the NewClientRegistration to be evaluated
-                let productId = (await ctx.environment.OnlySoftwareProduct());
+                let productId = (await ctx.environment.OnlySoftwareProductId());
                 let dependency = environment.TestServices.adrGateway.connectivity.DhNewClientRegistration(productId,dataholder);
 
                 try {
@@ -267,7 +267,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                 logger.debug(`Test new client registration with dataholder ${dataholder}`)
 
                 // Expect the NewClientRegistration to be evaluated
-                let dependency = environment.TestServices.adrGateway.connectivity.DhNewClientRegistration((await ctx.environment.OnlySoftwareProduct()),dataholder);
+                let dependency = environment.TestServices.adrGateway.connectivity.DhNewClientRegistration((await ctx.environment.OnlySoftwareProductId()),dataholder);
 
                 try {
                     await dependency.Evaluate({ignoreCache:"all"});
@@ -337,7 +337,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
             })
             .When(SetValue,async (ctx) => {
                 let reg:DataHolderRegistration = await ctx.GetTestContext(DcrSymbols.Context.NewClientRegistration).GetValue("Registration");
-                let at = await environment.TestServices.adrGateway?.connectivity.DhRegAccessToken(await ctx.environment.OnlySoftwareProduct(),reg.dataholderBrandId).Evaluate()
+                let at = await environment.TestServices.adrGateway?.connectivity.DhRegAccessToken(await ctx.environment.OnlySoftwareProductId(),reg.dataholderBrandId).Evaluate()
                 return at;
             },"Token")
             .Then(async ctx => {
@@ -355,7 +355,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
             })
             .When(SetValue,async (ctx) => {
                 let reg:DataHolderRegistration = await ctx.GetTestContext(DcrSymbols.Context.NewClientRegistration).GetValue("Registration");
-                let updatedReg = await environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProduct(),reg.dataholderBrandId).Evaluate()
+                let updatedReg = await environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProductId(),reg.dataholderBrandId).Evaluate()
                 return updatedReg;
             },"UpdatedRegistration")
             .Then(async ctx => {
@@ -380,7 +380,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
 
                 ClearDefaultInMemoryCache();
 
-                let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProduct(),dataholder);
+                let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProductId(),dataholder);
                 await dependency.Evaluate()
             },"ExistingRegistrationExecution")
             .Then(async ctx => {
@@ -462,7 +462,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                 try {
                     ClearDefaultInMemoryCache();
 
-                    let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProduct(),dataholder);
+                    let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProductId(),dataholder);
                 
                     await dependency.Evaluate()
                 } catch (err) {
@@ -511,7 +511,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                 try {
                     ClearDefaultInMemoryCache();
 
-                    let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProduct(),dataholder);
+                    let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(await ctx.environment.OnlySoftwareProductId(),dataholder);
                 
                     await dependency.Evaluate()
                 } catch (err) {
@@ -575,7 +575,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                     let pw = environment.TestServices.adrGateway?.connectivity;
                     if (!pw) throw 'Asserting that pw is not undefined'
                     
-                    let productKey = await ctx.environment.OnlySoftwareProduct();
+                    let productKey = await ctx.environment.OnlySoftwareProductId();
                     let productConfig = await ctx.environment.OnlySoftwareProductConfig();
                     let dhOidc = await pw.DataHolderOidc(dataholder).Evaluate();
                     let jwks = await pw.DataRecipientJwks().Evaluate();
@@ -624,7 +624,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                     old_ssa = await environment.GetPersistedValue("Old SSA")
                 } catch (e) {
                     logger.debug("Getting an SSA")
-                    let ssa = await environment.TestServices.adrGateway?.connectivity.SoftwareStatementAssertion(await ctx.environment.OnlySoftwareProduct()).Evaluate({ignoreCache:"all"})
+                    let ssa = await environment.TestServices.adrGateway?.connectivity.SoftwareStatementAssertion(await ctx.environment.OnlySoftwareProductId()).Evaluate({ignoreCache:"all"})
                     if (!ssa) throw 'Failed to get an SSA'
                     await environment.PersistValue("Old SSA",ssa);
                     logger.debug(`Received SSA: ${ssa}`);
@@ -652,7 +652,7 @@ export const Tests = ((environment:E2ETestEnvironment) => {
                 let DataHolderOidc = await pw.DataHolderOidc(dataholder).Evaluate();
                 let DataRecipientJwks = await pw.DataRecipientJwks().Evaluate();
                 let AdrConnectivityConfig = await pw.AdrConnectivityConfig().Evaluate();
-                let productKey = await ctx.environment.OnlySoftwareProduct();
+                let productKey = await ctx.environment.OnlySoftwareProductId();
                 let SoftwareProductConfig = await ctx.environment.OnlySoftwareProductConfig();
 
                 let DhRegAccessToken = await pw.DhRegAccessToken(productKey,dataholder).Evaluate();

--- a/src/Tests/EndToEnd/Framework/E2ETestEnvironment.ts
+++ b/src/Tests/EndToEnd/Framework/E2ETestEnvironment.ts
@@ -107,16 +107,18 @@ export class E2ETestEnvironment {
     }
 
     OnlySoftwareProductConfig = async ():Promise<SoftwareProductConnectivityConfig> => {
-        let softwareProduct = await this.OnlySoftwareProduct()
-        return this.TestServices.adrGateway.connectivity.SoftwareProductConfig(softwareProduct,undefined).Evaluate()
+        const softwareProduct = await this.OnlySoftwareProductKey()
+        const softwareProductId = (await this.TestServices.adrGateway.connectivity.SoftwareProductConfigs().Evaluate()).byKey[softwareProduct].ProductId;
+        return this.TestServices.adrGateway.connectivity.SoftwareProductConfig(softwareProductId).Evaluate()
     }
 
-    OnlySoftwareProduct = async () => {
-        let adrConfig = await this.TestServices.adrGateway.connectivity.AdrConnectivityConfig().Evaluate();
-        let softwareProduct = _.first(Object.keys(adrConfig.SoftwareProductConfigUris));
-        if (!softwareProduct) throw 'Expected exactly one software product to be configured';
-        return softwareProduct;
+    OnlySoftwareProductId = async () => {
+        const softwareProduct = await this.OnlySoftwareProductKey()
+        const softwareProductId = (await this.TestServices.adrGateway.connectivity.SoftwareProductConfigs().Evaluate()).byKey[softwareProduct].ProductId;
+        return softwareProductId;
     }
+
+    OnlySoftwareProductKey = () => "sandbox"
     
     Config:EndToEndTestingConfig
     SystemUnderTest = {

--- a/src/Tests/EndToEnd/Framework/TestData.ts
+++ b/src/Tests/EndToEnd/Framework/TestData.ts
@@ -168,7 +168,7 @@ const GenerateTestDataFromScratch = async (env:E2ETestEnvironment) => {
                 clientId: () => {
                     if (clientIdPromise) return clientIdPromise;
                     let dataholder = env.Config.SystemUnderTest.Dataholder;
-                    clientIdPromise = (env.OnlySoftwareProduct()).then(softwareProduct => {
+                    clientIdPromise = (env.OnlySoftwareProductId()).then(softwareProduct => {
                         return env.TestServices.adrGateway!.connectivity.BootstrapClientRegistration(softwareProduct,dataholder).Evaluate().then(reg => reg.clientId)
                     })
                     return clientIdPromise;

--- a/src/Tests/EndToEnd/Helpers/SwitchIdTokenAlgs.ts
+++ b/src/Tests/EndToEnd/Helpers/SwitchIdTokenAlgs.ts
@@ -63,7 +63,7 @@ export const SwitchIdTokenAlgs = async (environment: E2ETestEnvironment) => {
     const dataholder = environment.Config.SystemUnderTest.Dataholder;
     logger.debug(`Test new client registration with dataholder ${dataholder}`)
 
-    let softwareProductId = await environment.OnlySoftwareProduct();
+    let softwareProductId = await environment.OnlySoftwareProductId();
     let dependency = environment.TestServices.adrGateway?.connectivity.CheckAndUpdateClientRegistration(softwareProductId,dataholder);
 
     let interceptor = axios.interceptors.response.use(async res => {

--- a/src/Tests/EndToEnd/Helpers/TestConsentRequestor.ts
+++ b/src/Tests/EndToEnd/Helpers/TestConsentRequestor.ts
@@ -27,7 +27,9 @@ class TestConsentRequestor {
         sharingDuration: number
     }):Promise<ConsentRequestLog> => {
 
-        let spc = await this.testContext.environment.TestServices.adrGateway?.connectivity.SoftwareProductConfig("sandbox",undefined).Evaluate();
+        const softwareProductId = (await this.testContext.environment.TestServices.adrGateway.connectivity.SoftwareProductConfigs().Evaluate()).byKey["sandbox"].ProductId;
+
+        let spc = await this.testContext.environment.TestServices.adrGateway?.connectivity.SoftwareProductConfig(softwareProductId).Evaluate();
 
         const connection = await this.testContext.environment.TestServices.adrDbConn;
         if (!connection) throw 'No connection'
@@ -143,7 +145,7 @@ class TestConsentRequestor {
                 sharingDuration: params.sharingDuration,
                 state: `${params.systemId}:${params.userId}`,
                 additionalClaims: params.additionalClaims,
-                softwareProductId: await this.testContext.environment.OnlySoftwareProduct(),
+                softwareProductId: await this.testContext.environment.OnlySoftwareProductId(),
                 dataholderBrandId: params.dataholderBrandId
             },
         }));


### PR DESCRIPTION
Additional functionality and mock data:

- Remaining endpoints in the `banking` CDR schema now supported (with mock data)
- Optional ability for requesting client to supply post-consent redirect URI
- Instrumentation incorporated with initial implementation supported being Azure application insights