### PR TITLE
Bug fix to https proxy listeningPort config

### DIFF
--- a/src/HttpsProxy/proxy.ts
+++ b/src/HttpsProxy/proxy.ts
@@ -84,7 +84,7 @@ export const spawnHttpsProxy = (config: { ProxyConfig: Dictionary<ProxySpec> }, 
     requestCert: tlsConfig.requestCert
   }) || {}
 
-  let httpsPort = defaultHttpsPort || routeConfig.listeningPort
+  let httpsPort = routeConfig?.listeningPort || defaultHttpsPort
 
   let server = https.createServer(serverOpts, app).listen(httpsPort, () => logger.info(`${name} listening on HTTPS port ${httpsPort}!`))
 


### PR DESCRIPTION
The https mock proxy wasn't actually listening to the listeningPort config. :slightly_smiling_face: 